### PR TITLE
Fix and expand sample page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Blockies
 
 A tiny library for generating blocky identicons.
 
-![Sample blockies image](sample.png "Blockies")
+![Sample blockies image](samples/sample.png "Blockies")
 
-[**Demo page**](http://download13.github.io/blockies/)
+[**Demo page**](http://htmlpreview.github.io/?https://github.com/101100/blockies/blob/fix-sample-page/samples/ethereum-address-sample.html)
 
 Use
 ---

--- a/samples/ethereum-address-sample.html
+++ b/samples/ethereum-address-sample.html
@@ -7,19 +7,35 @@
     height: 64px;
     background-size: cover;
     background-repeat: no-repeat;
-    border-radius: 50%;
+    border-radius: 20%;
     box-shadow: inset rgba(255, 255, 255, 0.6) 0 2px 2px, inset rgba(0, 0, 0, 0.3) 0 -2px 6px;
+}
+input[type=text] {
+    width: 100%;
+    padding: 2px 10px;
+    margin: 8px 0;
+    box-sizing: border-box;
 }
 </style>
 </head>
 <body>
     <div id="icon"></div>
-    <script src="blockies.js"></script>
+    <input id="address" type="text"></input>
+    <script src="../dist/blockies.js"></script>
     <script>
+        var defaultAddress = '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359';
 
-        var address = '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359';
+        var addressText = document.getElementById("address");
         var icon = document.getElementById('icon');
-        icon.style.backgroundImage = 'url(' + blockies.create({ seed:address ,size: 8,scale: 16}).toDataURL()+')'
 
+        addressText.value = defaultAddress;
+        addressText.addEventListener('input', addressChange);
+
+        function addressChange(){
+            var address = addressText.value || defaultAddress;
+            icon.style.backgroundImage = 'url(' + blockies.toDataUrl(address) + ')';
+        }
+
+        addressChange();
     </script>
 </body>


### PR DESCRIPTION
This fixes the sample page (the relative URL for the `blockies.js` file was wrong) and adds an easy way to see icons for a particular address.